### PR TITLE
Removes compiler warnings about converting a string constants

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Configure CMake
-      run: cmake -S . -B ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     
     - name: Build example project
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target examples

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -37,5 +37,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ../src/example
-        make 
+        cmake ../src/example -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+    
+    - name: Build example project
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -34,10 +34,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Configure CMake
-      run: |
-        mkdir build
-        cd build
-        cmake ../src/example -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -S ${{github.workspace}}/src/example -B ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     
     - name: Build example project
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -31,5 +31,5 @@ jobs:
       working-directory: ${{github.workspace}}
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ${{github.workspace}}/bin/testGeolib
+      run: ${{github.workspace}}/bin/testGeolib -t
 

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -2,11 +2,8 @@
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
 name: CMake on a single platform
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: push
+
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -4,7 +4,7 @@ name: CMake on a single platform
 
 on: push
 
-env:
+# env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   # BUILD_TYPE: Release
   # CC: gcc-8
@@ -28,11 +28,11 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -S . -B ${{github.workspace}}/build #-DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -S . -B ${{github.workspace}}/build 
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build #--config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build 
 
     - name: Test
       working-directory: ${{github.workspace}}

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -27,14 +27,15 @@ jobs:
       working-directory: ${{github.workspace}}
       run: ${{github.workspace}}/bin/testGeolib -t
   
-  # build-example:
-  #   runs-on: ubuntu-22.04
+  build-example:
+    runs-on: ubuntu-22.04
     
-  #   steps:
-  #   - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  #   - name: Configure CMake
-  #     run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-    
-  #   - name: Build example project
-  #     run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target examples
+    - name: Build examples
+      run: |
+        mkdir build
+        cd build
+        cmake ../src/example
+        make

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -15,7 +15,11 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
-
+    
+    env:
+      CC: gcc-8
+      CXX: g++-8
+    
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -4,10 +4,11 @@ name: CMake on a single platform
 
 on: push
 
-
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  CC: gcc-8
+  CXX: g++-8
 
 jobs:
   build:
@@ -16,12 +17,13 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
     
-    env:
-      CC: gcc-8
-      CXX: g++-8
-    
     steps:
     - uses: actions/checkout@v3
+
+    - name: Install g++ version 8
+      run: |
+        sudo apt update
+        sudo apt install gcc-8 g++-8
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -7,8 +7,6 @@ on: push
 # env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   # BUILD_TYPE: Release
-  # CC: gcc-8
-  # CXX: g++-8
 
 jobs:
   build:
@@ -19,11 +17,6 @@ jobs:
     
     steps:
     - uses: actions/checkout@v3
-
-    # - name: Install g++ version 8
-    #   run: |
-    #     sudo apt update
-    #     sudo apt install gcc-8 g++-8
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -38,5 +31,5 @@ jobs:
       working-directory: ${{github.workspace}}
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ./bin/testGeolib
+      run: ${{github.workspace}}/bin/testGeolib
 

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -27,7 +27,6 @@ jobs:
 
     - name: Build example project
       run: |
-        mkdir build
         cd build
         cmake ../src/example
         make

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -4,7 +4,8 @@ name: CMake on a single platform
 
 on: push
 
-# env:
+env:
+  FILEROOT: "."
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   # BUILD_TYPE: Release
 

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -10,7 +10,7 @@ env:
   # BUILD_TYPE: Release
 
 jobs:
-  build:
+  build-library:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
@@ -25,13 +25,19 @@ jobs:
     - name: Build geolib and tests
       run: cmake --build ${{github.workspace}}/build 
 
-    - name: Build example project
-      run: |
-        cd src/example
-        cmake -S . -B ${{github.workspace}}/build 
-        cmake --build ${{github.workspace}}/build 
-
     - name: Test
       working-directory: ${{github.workspace}}
       run: ${{github.workspace}}/bin/testGeolib -t
+  
+  build-example:
+    runs-on: ubuntu-22.04
+    
+    steps:
+    - uses: actions/checkout@v3
 
+    - name: Configure CMake
+      run: |
+        mkdir build
+        cd build
+        cmake ../src/example
+        make 

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -1,0 +1,39 @@
+# This starter workflow is for a CMake project running on a single platform. There is a different starter workflow if you need cross-platform coverage.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
+name: CMake on a single platform
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ./bin/testGeolib
+

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -37,5 +37,5 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ../src/example
+        cmake ../src/example -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         make

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Configure CMake
-      run: cmake -S ${{github.workspace}}/src/example -B ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -S . -B ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     
     - name: Build example project
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target examples

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -5,9 +5,7 @@ name: CMake on a single platform
 on: push
 
 env:
-  FILEROOT: "."
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  # BUILD_TYPE: Release
+  BUILD_TYPE: Release
 
 jobs:
   build-library:
@@ -20,10 +18,10 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Configure CMake
-      run: cmake -S . -B ${{github.workspace}}/build 
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build geolib and tests
-      run: cmake --build ${{github.workspace}}/build 
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Test
       working-directory: ${{github.workspace}}

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -27,9 +27,9 @@ jobs:
 
     - name: Build example project
       run: |
-        cd build
-        cmake ../src/example
-        make
+        cd src/example
+        cmake -S . -B ${{github.workspace}}/build 
+        cmake --build ${{github.workspace}}/build 
 
     - name: Test
       working-directory: ${{github.workspace}}

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -15,7 +15,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -21,20 +21,20 @@ jobs:
       run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build geolib and tests
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} 
 
     - name: Test
       working-directory: ${{github.workspace}}
       run: ${{github.workspace}}/bin/testGeolib -t
   
-  build-example:
-    runs-on: ubuntu-22.04
+  # build-example:
+  #   runs-on: ubuntu-22.04
     
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - name: Configure CMake
-      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+  #   - name: Configure CMake
+  #     run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     
-    - name: Build example project
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target examples
+  #   - name: Build example project
+  #     run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target examples

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -6,33 +6,33 @@ on: push
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-  CC: gcc-8
-  CXX: g++-8
+  # BUILD_TYPE: Release
+  # CC: gcc-8
+  # CXX: g++-8
 
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install g++ version 8
-      run: |
-        sudo apt update
-        sudo apt install gcc-8 g++-8
+    # - name: Install g++ version 8
+    #   run: |
+    #     sudo apt update
+    #     sudo apt install gcc-8 g++-8
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -S . -B ${{github.workspace}}/build #-DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build #--config ${{env.BUILD_TYPE}}
 
     - name: Test
       working-directory: ${{github.workspace}}

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -20,17 +20,19 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -S . -B ${{github.workspace}}/build 
 
-    - name: Build
-      # Build your program with the given configuration
+    - name: Build geolib and tests
       run: cmake --build ${{github.workspace}}/build 
+
+    - name: Build example project
+      run: |
+        mkdir build
+        cd build
+        cmake ../src/example
+        make
 
     - name: Test
       working-directory: ${{github.workspace}}
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ${{github.workspace}}/bin/testGeolib -t
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(GEOLIB VERSION 3.2.7.1) # the nano value is a boolean. 1 == SNAPSHOT, 0 == release
+project(GEOLIB VERSION 3.2.8.1) # the nano value is a boolean. 1 == SNAPSHOT, 0 == release
 
 set (CMAKE_CXX_STANDARD 11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,4 +55,3 @@ set (TEST_SRC_DIR
 # Look at the subdirectory definitions to understand the build details
 add_subdirectory(${GEOLIB_SRC_DIR})
 add_subdirectory(${TEST_SRC_DIR})
-add_subdirectory(${PROJECT_SOURCE_DIR}/src/example)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,3 +55,4 @@ set (TEST_SRC_DIR
 # Look at the subdirectory definitions to understand the build details
 add_subdirectory(${GEOLIB_SRC_DIR})
 add_subdirectory(${TEST_SRC_DIR})
+add_subdirectory(${PROJECT_SOURCE_DIR}/src/example)

--- a/include/geolib/Util.h
+++ b/include/geolib/Util.h
@@ -323,7 +323,7 @@ LLPoint mapVectorToSphere(Vector v);
  * @param displayRadians Flag to determine output in degrees (0) or radians (1) (int)
  * @return Returns a string containing properties of the input LLPoint
  */
-char *createPtString(LLPoint p, char *pointName, OutputMode mode, int displayRadians);
+char *createPtString(LLPoint p, const char *pointName, OutputMode mode, int displayRadians);
 
 /** Creates a string describing the properties of a Geodesic in the desired format
  * @param g Geodesic to be described (Geodesic)
@@ -332,7 +332,7 @@ char *createPtString(LLPoint p, char *pointName, OutputMode mode, int displayRad
  * @param displayRadians Flag to determine output in degrees (0) or radians (1) (int)
  * @return Returns a string containing properties of the input Geodesic
  */
-char *createGeoString(Geodesic g, char *geoName, OutputMode mode, int displayRadians);
+char *createGeoString(Geodesic g, const char *geoName, OutputMode mode, int displayRadians);
 
 /** Creates a string describing the properties of a Locus in the desired format
  * @param l Locus to be described (Locus)
@@ -350,7 +350,7 @@ char *createLocusString(Locus l, char *locusName, OutputMode mode, int displayRa
  * @param displayRadians Flag to determine output in degrees (0) or radians (1) (int)
  * @return Returns a string containing properties of the input Arc
  */
-char *createArcString(Arc a, char *arcName, OutputMode mode, int displayRadians);
+char *createArcString(Arc a, const char *arcName, OutputMode mode, int displayRadians);
 
 /** Creates a string describing the properties of a Spiral in the desired format
  * @param a Spiral to be described (Spiral)
@@ -449,7 +449,7 @@ void displayComplexBndry(ComplexBoundary c, char *complexBoundaryName, int displ
  * @return Prints the properties of the LLPoint to the system console in the proper format
  * @retval Nothing
  */
-void displayMatlabPt(LLPoint p, char *pointName, int displayRadians);
+void displayMatlabPt(LLPoint p, const char *pointName, int displayRadians);
 
 /** Prints the properties of a Geodesic to the console in a Matlab friendly format
  * @param g Geodesic to be described (Geodesic)
@@ -458,7 +458,7 @@ void displayMatlabPt(LLPoint p, char *pointName, int displayRadians);
  * @return Prints the properties of the Geodesic to the system console in the proper format
  * @retval Nothing
  */
-void displayMatlabGeo(Geodesic g, char *geoName, int displayRadians);
+void displayMatlabGeo(Geodesic g, const char *geoName, int displayRadians);
 
 /** Prints the properties of a Locus to the console in a Matlab friendly format
  * @param l Locus to be described (Locus)
@@ -476,7 +476,7 @@ void displayMatlabLocus(Locus l, char *locusName, int displayRadians);
  * @return Prints the properties of the Arc to the system console in the proper format
  * @retval Nothing
  */
-void displayMatlabArc(Arc a, char *arcName, int displayRadians);
+void displayMatlabArc(Arc a, const char *arcName, int displayRadians);
 
 /** Prints the properties of a Spiral to the console in a Matlab friendly format
  * @param a Spiral to be described (Spiral)

--- a/include/test/testUtil.h
+++ b/include/test/testUtil.h
@@ -118,7 +118,7 @@ void newpause();
 //TODO This function is a temporary duplicate of the displayLocus function.
 //Once the refactoring of libWGS84.c is complete and displayLocus is public
 //all references to printLocus should be replaced with displayLocus.
-void printLocus(char* locusName, Locus locus);
+void printLocus(const char* locusName, Locus locus);
 
 double crsZeroToTwoPI(double crs);
 

--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
 
-set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 # -----------

--- a/src/c/Display.cc
+++ b/src/c/Display.cc
@@ -135,13 +135,13 @@ void geolib_idealab::aboutGeolib(char *result, const unsigned int size)
 	}
 }
 
-char* geolib_idealab::createPtString(LLPoint p, char* pointName, OutputMode mode, int displayRadians)
+char* geolib_idealab::createPtString(LLPoint p, const char* pointName, OutputMode mode, int displayRadians)
 {
 	char* string = static_cast<char *>(calloc(sizeof(char), 500));
 
     double lat = p.latitude;
     double lon = p.longitude;
-    char* angleUnits = "rad";
+    const char* angleUnits = "rad";
     char conversion[10] = "";
     const int maxNameLen = 100;
     char name[101];//+1 is for terminating character '\0'
@@ -188,7 +188,7 @@ char* geolib_idealab::createPtString(LLPoint p, char* pointName, OutputMode mode
 	return string;
 }
 
-char* geolib_idealab::createGeoString(Geodesic g, char* geoName, OutputMode mode, int displayRadians)
+char* geolib_idealab::createGeoString(Geodesic g, const char* geoName, OutputMode mode, int displayRadians)
 {
 	char* string = static_cast<char *>(calloc(sizeof(char), 2000));
     char conversion[10] = "";
@@ -210,7 +210,7 @@ char* geolib_idealab::createGeoString(Geodesic g, char* geoName, OutputMode mode
     double startAz = g.startAz;
     double endAz = g.endAz;
     double revAz = modpos(g.endAz + M_PI, M_2PI );
-    char* angleUnits = "rad";
+    const char* angleUnits = "rad";
 
     if (!displayRadians)
     {
@@ -283,7 +283,7 @@ char* geolib_idealab::createGeoString(Geodesic g, char* geoName, OutputMode mode
 	return string;
 }
 
-char* geolib_idealab::createArcString(Arc a, char* arcName, OutputMode mode, int displayRadians)
+char* geolib_idealab::createArcString(Arc a, const char* arcName, OutputMode mode, int displayRadians)
 {
 	char* string = static_cast<char *>(calloc(sizeof(char), 3000));
     char conversion[10] = "";
@@ -313,7 +313,7 @@ char* geolib_idealab::createArcString(Arc a, char* arcName, OutputMode mode, int
     double endAz = a.endAz;
     double subtendedAngle = a.subtendedAngle;
     double midPtCrs;
-    char* angleUnits = "rad";
+    const char* angleUnits = "rad";
 
 	//compute the course from the arc center to the arc mid point
 	midPtCrs = modpos(a.startAz + (0.5*a.subtendedAngle), M_2PI);//subtended angle is signed already
@@ -459,7 +459,7 @@ char* geolib_idealab::createSpiralString(Spiral sp, char* spiralName, OutputMode
     double endAz = sp.endAz;
     double subtendedAngle = sp.subtendedAngle;
     double growthRate = sp.growthRate;
-    char* angleUnits = "rad";
+    const char* angleUnits = "rad";
 
     if (!displayRadians)
     {
@@ -600,7 +600,7 @@ char* geolib_idealab::createLocusString(Locus l, char* locusName, OutputMode mod
     double startAz = l.geoAz;
     double endAz = modpos(l.geoRevAz + M_PI, M_2PI );
     double revAz = l.geoRevAz;
-    char* angleUnits = "rad";
+    const char* angleUnits = "rad";
 
     if (!displayRadians)
     {
@@ -875,7 +875,7 @@ void geolib_idealab::displayComplexBndry(ComplexBoundary c, char* complexBoundar
 	printf("%s", output);
 }
 
-void geolib_idealab::displayMatlabPt(LLPoint p, char* pointName, int displayRadians)
+void geolib_idealab::displayMatlabPt(LLPoint p, const char* pointName, int displayRadians)
 {
 	char* output;
 
@@ -883,7 +883,7 @@ void geolib_idealab::displayMatlabPt(LLPoint p, char* pointName, int displayRadi
 	printf("%s", output);
 }
 
-void geolib_idealab::displayMatlabGeo(Geodesic g, char* geoName, int displayRadians)
+void geolib_idealab::displayMatlabGeo(Geodesic g, const char* geoName, int displayRadians)
 {
 	char* output;
 
@@ -891,7 +891,7 @@ void geolib_idealab::displayMatlabGeo(Geodesic g, char* geoName, int displayRadi
 	printf("%s", output);
 }
 
-void geolib_idealab::displayMatlabArc(Arc a, char* arcName, int displayRadians)
+void geolib_idealab::displayMatlabArc(Arc a, const char* arcName, int displayRadians)
 {
 	char* output;
 

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -8,9 +8,9 @@ include(${PROJECT_SOURCE_DIR}/../../.cmake/CPM.cmake)
 
 CPMAddPackage(
         NAME geolib_library
-        GITHUB_REPOSITORY mitre/geodetic_library
+        GITHUB_REPOSITORY ddrake-mitre/geodetic_library
         VERSION 3.2.7-SNAPSHOT
-        GIT_TAG main
+        GIT_TAG 2a8ee52
 )
 
 # Define source files for this executable

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -8,9 +8,9 @@ include(${PROJECT_SOURCE_DIR}/../../.cmake/CPM.cmake)
 
 CPMAddPackage(
         NAME geolib_library
-        GITHUB_REPOSITORY ddrake-mitre/geodetic_library
+        GITHUB_REPOSITORY mitre/geodetic_library
         VERSION 3.2.7-SNAPSHOT
-        GIT_TAG 2a8ee52
+        GIT_TAG main
 )
 
 # Define source files for this executable

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(GEOLIB_EXAMPLE VERSION 0.0.1)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 
 include(${PROJECT_SOURCE_DIR}/../../.cmake/CPM.cmake)
 

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -8,9 +8,9 @@ include(${PROJECT_SOURCE_DIR}/../../.cmake/CPM.cmake)
 
 CPMAddPackage(
         NAME geolib_library
-        GITHUB_REPOSITORY ddrake-mitre/geodetic_library
+        GITHUB_REPOSITORY mitre/geodetic_library
         VERSION 3.2.7-SNAPSHOT
-        GIT_TAG "bugfix/remove-string-constant-compiler-warnings"
+        GIT_TAG main
 )
 
 # Define source files for this executable

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -8,9 +8,9 @@ include(${PROJECT_SOURCE_DIR}/../../.cmake/CPM.cmake)
 
 CPMAddPackage(
         NAME geolib_library
-        GITHUB_REPOSITORY mitre/geodetic_library
+        GITHUB_REPOSITORY ddrake-mitre/geodetic_library
         VERSION 3.2.7-SNAPSHOT
-        GIT_TAG main
+        GIT_TAG "bugfix/remove-string-constant-compiler-warnings"
 )
 
 # Define source files for this executable

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wwritable-strings -Wno-sign-compare -O3 -g3")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wno-sign-compare -O3 -g3")
 
 SET(TEST_CLASSES
     testArc/src/testArc.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,22 +1,16 @@
-# Use this to build the tests
 cmake_minimum_required(VERSION 3.14)
-
-set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wwritable-strings -Wno-sign-compare -O3 -g3")
 
 SET(TEST_CLASSES
     testArc/src/testArc.cc
-#    testBoundary/src/testBoundary.cc
     testGeodesic/src/testGeodesic.cc
     testLocus/src/testLocus.cc
     testLLPoint/src/testLLPoint.cc 
     testShape/src/testShape.cc
-#    testSpiral/src/testSpiral.cc
     testVector/src/testVector.cc
     )
 
-# Define source files for this executable
 SET(TEST_SRC
         ${TEST_SRC_DIR}/testGeolib.cc
         ${TEST_SRC_DIR}/testUtil.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,10 @@ SET(TEST_SRC
 add_executable(testGeolib ${TEST_SRC})
 target_include_directories(testGeolib PUBLIC ${geolib_INCLUDE_DIRS} ${geolib_test_INCLUDE_DIRS})
 target_link_libraries(testGeolib geolib)
-set_target_properties(testGeolib PROPERTIES
+target_compile_definitions(testGeolib 
+        PRIVATE 
+        FILEROOT=".")
+set_target_properties(testGeolib 
+        PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin
         )

--- a/test/testUtil.cc
+++ b/test/testUtil.cc
@@ -516,7 +516,7 @@ void outputTestSuiteXML(const TestSuite &suite, const int level, FILE* file)
  */
 void outputTestSuiteMetrics(TestSuite suite, char* outputFile)
 {
-    char* fileLocation = FILEROOT "/test/";
+    const char* fileLocation = FILEROOT "/test/";
     char fileName[100];
     char timeStamp[100];
     char completeFilePath[500];
@@ -963,7 +963,7 @@ void newpause(void)
 //TODO This function is a temporary duplicate of the displayLocus function.
 //Once the refactoring of libWGS84.c is complete and displayLocus is public
 //all references to printLocus should be replaced with displayLocus.
-void printLocus(char* locusName, Locus locus)
+void printLocus(const char* locusName, Locus locus)
 {
     double DEG2RAD = M_PI / 180.0;
     double locslope = atan((locus.endDist - locus.startDist) / locus.geoLength);


### PR DESCRIPTION
I made several changes to remove compiler warnings, and to fix external builds using the cmake `Release` configuration. I had to build the example against my own changed branch through CPM before rolling the CPM back to point at this repository.

The passing build can be seen here though:
https://github.com/ddrake-mitre/geodetic_library/actions/runs/6830537798/job/18578626110

Once this branch is merged, the CPM.cmake example can be updated.