### PR TITLE
fix: sets the same version of CMake required across all cmake files

### DIFF
--- a/.cmake/functions.cmake
+++ b/.cmake/functions.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 
 #===================================================================================
 # Returns all variables (as a list) that start with prefix.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(GEOLIB VERSION 3.2.8.1) # the nano value is a boolean. 1 == SNAPSHOT, 0 == release
+project(GEOLIB VERSION 3.2.9.0) # the nano value is a boolean. 1 == SNAPSHOT, 0 == release
 
 set (CMAKE_CXX_STANDARD 11)
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Drop this in the appropriate place for your application:
 CPMAddPackage(
         NAME geolib_library
         GITHUB_REPOSITORY mitre/geodetic_library
-        VERSION 3.2.8
+        VERSION 3.2.9
         GIT_TAG main
 )
 ```

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Drop this in the appropriate place for your application:
 CPMAddPackage(
         NAME geolib_library
         GITHUB_REPOSITORY mitre/geodetic_library
-        VERSION 3.2.7-SNAPSHOT
+        VERSION 3.2.8
         GIT_TAG main
 )
 ```

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -9,7 +9,7 @@ include(${PROJECT_SOURCE_DIR}/../../.cmake/CPM.cmake)
 CPMAddPackage(
         NAME geolib_library
         GITHUB_REPOSITORY mitre/geodetic_library
-        VERSION 3.2.8
+        VERSION 3.2.9
         GIT_TAG main
 )
 

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -9,7 +9,7 @@ include(${PROJECT_SOURCE_DIR}/../../.cmake/CPM.cmake)
 CPMAddPackage(
         NAME geolib_library
         GITHUB_REPOSITORY mitre/geodetic_library
-        VERSION 3.2.7-SNAPSHOT
+        VERSION 3.2.8
         GIT_TAG main
 )
 


### PR DESCRIPTION
The functions.cmake file has a much earlier version of CMake specified which will cause build failures in FMACM with CMake v4.0. 